### PR TITLE
Automatically find link references for stops

### DIFF
--- a/db/030_functions_nw.sql
+++ b/db/030_functions_nw.sql
@@ -53,7 +53,8 @@ AS $$
       ST_LineLocatePoint(vld.geom, st.geom) AS location_on_link,
       ST_Distance(vld.geom, st.geom)        AS distance_from_link
     FROM nw.view_link_directed AS vld
-    WHERE ARRAY[st.stop_mode] <@ vld.link_modes
+    WHERE ST_DWithin(vld.geom, st.geom, max_distance_m)
+      AND ARRAY[st.stop_mode] <@ vld.link_modes
       AND ST_Contains(
         ST_Buffer(vld.geom, max_distance_m, 'side=right'),
         st.geom)

--- a/db/030_functions_nw.sql
+++ b/db/030_functions_nw.sql
@@ -77,10 +77,24 @@ BEGIN
   SELECT INTO n_total count(*) FROM nw.stop;
   SELECT INTO n_manual count(*) FROM nw.stop WHERE link_ref_manual;
 
-  -- TODO: Invoke the above function inside an UPDATE statement
-  n_updated := 0;
+  WITH updated AS (
+    UPDATE nw.stop AS st
+    SET
+      link_id = upd.link_id,
+      link_dir = upd.link_dir,
+      location_on_link = upd.location_on_link,
+      distance_from_link = upd.distance_from_link
+    FROM (
+      SELECT * FROM nw.get_stop_link_refs(max_distance_m := max_distance_m)
+    ) AS upd
+    WHERE st.stop_id = upd.stop_id
+      AND NOT st.link_ref_manual
+    RETURNING 1
+  )
+  SELECT INTO n_updated count(*)
+  FROM updated;
 
   RAISE INFO '% nw.stop records updated (total % stops, % protected from updates)',
-    n_updated, n_total, n_updated;
+    n_updated, n_total, n_manual;
 END;
 $$;

--- a/db/030_functions_nw.sql
+++ b/db/030_functions_nw.sql
@@ -1,0 +1,71 @@
+/*
+ * Functions and procedures related to nw schema.
+ * Note that trigger functions are not declared here,
+ * instead they are in 020_schema_nw.sql with their relations.
+ */
+
+/*
+ * # Updating link references to nw.stop records
+ *
+ * The first function finds the nearest link for each stop point
+ * and the relative location along the link,
+ * and returns a set of the results (so it can be used without side effects).
+ * Stops marked with link_ref_manual = true and further than max_distance_m away
+ * from the nearest link are not considered.
+ * In case of two-way links, the correct direction to use is determined
+ * such that the stop shall lie on the right-hand side of the link,
+ * viewed from the link start to end node.
+ *
+ * The second procedure is just for calling the first one and saving the results
+ * to the actual nw.stop table by stop_id.
+ * Example:
+ *
+ * > CALL nw.update_stop_link_refs(30.0);
+ */
+
+CREATE FUNCTION nw.get_stop_link_refs(
+  max_distance_m float8 DEFAULT 20.0
+)
+RETURNS TABLE (
+    stop_id             integer,
+    link_id             integer,
+    link_dir            smallint,
+    location_on_link    float8,
+    distance_from_link  float8
+)
+STABLE
+PARALLEL SAFE
+LANGUAGE SQL
+AS $$
+  SELECT
+    st.stop_id,
+    li.link_id,
+    li.link_dir,
+    ST_LineLocatePoint(li.geom, st.geom)  AS location_on_link,
+    ST_Distance(li.geom, st.geom)         AS distance_from_link
+  FROM nw.stop AS st
+  INNER JOIN nw.view_link_directed AS li
+    ON ST_DWithin(st.geom, li.geom, max_distance_m)
+  ORDER BY st.stop_id, ST_Distance(st.geom, li.geom);
+$$;
+
+CREATE PROCEDURE nw.update_stop_link_refs(
+  max_distance_m float8 DEFAULT 20.0
+)
+LANGUAGE PLPGSQL
+AS $$
+DECLARE
+  n_total   integer;
+  n_manual  integer;
+  n_updated integer;
+BEGIN
+  SELECT INTO n_total count(*) FROM nw.stop;
+  SELECT INTO n_manual count(*) FROM nw.stop WHERE link_ref_manual;
+
+  -- TODO: Invoke the above function inside an UPDATE statement
+  n_updated := 0;
+  
+  RAISE INFO '% nw.stop records updated (total % stops, % protected from updates)',
+    n_updated, n_total, n_updated;
+END;
+$$;

--- a/example_data/import.sql
+++ b/example_data/import.sql
@@ -3,3 +3,4 @@
 \copy nw.view_stop_wkt FROM '/data/stop.csv' CSV HEADER;
 \copy nw.route_version (route_ver_id, route, dir, valid_during, route_mode) FROM '/data/route_version.csv' CSV HEADER;
 \copy nw.stop_on_route FROM '/data/stop_on_route.csv' CSV HEADER;
+CALL nw.update_stop_link_refs(20.0);


### PR DESCRIPTION
Fixes #57.

Now we are able to connect stops to links like this:

![image](https://user-images.githubusercontent.com/36631098/117181287-bc180300-addd-11eb-83ad-3bc8497906f9.png)

The red areas (20 m in the picture) show the right-hand buffer areas from the oneway link versions, considered when matching stops to the closest links. If a stop does not fall within a side buffer area, it will not get a link reference automatically:

![image](https://user-images.githubusercontent.com/36631098/117181534-01d4cb80-adde-11eb-980e-cb6551d5294a.png)

I.e., the red stop point should be moved below the link so it gets correctly to the right-hand side of it.