### PR TITLE
Add a view and triggers for interactive modifications of sections

### DIFF
--- a/db/020_schema_nw.sql
+++ b/db/020_schema_nw.sql
@@ -361,3 +361,20 @@ CREATE VIEW nw.view_link_on_section_geom AS (
   INNER JOIN nw.view_link_directed  AS ld
     ON (los.link_id = ld.link_id AND los.link_reversed = ld.link_reversed)
 );
+
+CREATE VIEW nw.view_section_ij_line AS (
+  SELECT
+    se.section_id,
+    se.description,
+    se.report,
+    se.rotation,
+    se.via_nodes[1]                         AS i_node,
+    se.via_nodes[cardinality(se.via_nodes)] AS j_node,
+    ST_MakeLine(ind.geom, jnd.geom)         AS geom
+  FROM nw.section AS se
+  INNER JOIN nw.node  AS ind
+    ON (se.via_nodes[1] = ind.node_id)
+  INNER JOIN nw.node  AS jnd
+    ON (se.via_nodes[cardinality(se.via_nodes)] = jnd.node_id)
+  WHERE cardinality(se.via_nodes) > 1
+);

--- a/db/020_schema_nw.sql
+++ b/db/020_schema_nw.sql
@@ -438,3 +438,22 @@ $$ LANGUAGE PLPGSQL;
 CREATE TRIGGER tg_upsert_section_ij_line
 INSTEAD OF INSERT OR UPDATE ON nw.view_section_ij_line
 FOR EACH ROW EXECUTE PROCEDURE nw.tg_upsert_section_ij_line();
+
+CREATE FUNCTION nw.tg_delete_section_ij_line()
+RETURNS trigger
+AS $$
+BEGIN
+
+  DELETE FROM nw.link_on_section
+  WHERE section_id = OLD.section_id;
+
+  DELETE FROM nw.section
+  WHERE section_id = OLD.section_id;
+
+  RETURN OLD;
+END;
+$$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER tg_delete_section_ij_line
+INSTEAD OF DELETE ON nw.view_section_ij_line
+FOR EACH ROW EXECUTE PROCEDURE nw.tg_delete_section_ij_line();


### PR DESCRIPTION
This PR makes it possible to modify analysis sections in QGIS like this:

![Peek 2021-06-07 13-50](https://user-images.githubusercontent.com/36631098/121004623-947ad880-c797-11eb-9a07-4701ace66a35.gif)

Currently, we can only save sections with exactly two via points (i and j, or start and end) with this method. We could later develop this further so that the view takes _all_ points of the linestring into account as via points.