### PR TITLE
Set signed distance_from_link

### DIFF
--- a/db/050_schema_obs.sql
+++ b/db/050_schema_obs.sql
@@ -182,7 +182,7 @@ COMMENT ON COLUMN obs.point_on_link.link_reversed IS
 COMMENT ON COLUMN obs.point_on_link.location_on_link IS
 'Projected relative location along the link, between 0.0 and 1.0. Use link length with this to get the absolute location.';
 COMMENT ON COLUMN obs.point_on_link.distance_from_link IS
-'Distance between original and link-projected position.';
+'Distance between original and link-projected position. Negative, if point is on the left side of directed link.';
 
 SELECT create_hypertable(
   relation            => 'obs.point_on_link',

--- a/db/060_functions_obs.sql
+++ b/db/060_functions_obs.sql
@@ -59,7 +59,10 @@ SELECT
   abs(
     ST_LineLocatePoint(li.geom, hfp.geom) - (lor.link_reversed::integer)
   )                                       AS location_on_link,
-  ST_Distance(li.geom, hfp.geom)          AS distance_from_link
+  -- Set negative distance when point is on the left side of directed link.
+  (CASE WHEN ST_Contains(ST_Buffer(li.geom, $1, 'side=left'), hfp.geom)
+    THEN -1 ELSE 1 END
+  ) * ST_Distance(li.geom, hfp.geom)      AS distance_from_link
 FROM obs.hfp_point          AS hfp
 INNER JOIN obs.journey      AS jrn
   ON (hfp.jrnid = jrn.jrnid)


### PR DESCRIPTION
This is useful when analyzing the point to link match quality in a 2D plot: directionality of the distances can be shown on the y axis, for instance. Positive distances can still be calculated using `abs()`.

Closes #110.