### PR TITLE
Fix exclusion constraint in `nw.route_version`

### DIFF
--- a/db/020_schema_nw.sql
+++ b/db/020_schema_nw.sql
@@ -304,7 +304,7 @@ CREATE TABLE nw.route_version (
   route_mode    nw.vehicle_mode NOT NULL,
   errors        text[],
 
-  EXCLUDE USING GIST (route_ver_id WITH =, valid_during WITH &&)
+  EXCLUDE USING GIST (route WITH =, dir WITH =, valid_during WITH &&)
 );
 
 COMMENT ON TABLE nw.route_version IS


### PR DESCRIPTION
so it enforces non-overlapping validity periods of route-dir combinations, not route_ver_id values that are arbitrary, in the end. 

Closes #103.